### PR TITLE
Remove deprecated ::add-path:: from GitHub Actions

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -25,7 +25,10 @@ jobs:
     - name: Install Poetry
       run: |
         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-        echo ::set-env name=PATH::$HOME/.poetry/bin:$PATH
+
+    - name: Add Poetry to PATH
+      run: |
+        echo $HOME/.poetry/bin:$PATH >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Add Poetry to PATH
       run: |
-        echo "$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+        echo "$PATH:$HOME/.poetry/bin" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Add Poetry to PATH
       run: |
-        echo "$PATH:$HOME/.poetry/bin" >> $GITHUB_ENV
+        echo "PATH=$PATH:$HOME/.poetry/bin" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Add Poetry to PATH
       run: |
-        echo $HOME/.poetry/bin:$PATH >> $GITHUB_ENV
+        echo "$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -25,7 +25,10 @@ jobs:
     - name: Install Poetry
       run: |
         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-        echo ::set-env name=PATH::$HOME/.poetry/bin:$PATH
+
+    - name: Add Poetry to PATH
+      run: |
+        echo $HOME/.poetry/bin:$PATH >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Add Poetry to PATH
       run: |
-        echo "$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+        echo "$PATH:$HOME/.poetry/bin" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Add Poetry to PATH
       run: |
-        echo "$PATH:$HOME/.poetry/bin" >> $GITHUB_ENV
+        echo "PATH=$PATH:$HOME/.poetry/bin" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Add Poetry to PATH
       run: |
-        echo $HOME/.poetry/bin:$PATH >> $GITHUB_ENV
+        echo "$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: "Poetry: add to %PATH%"
       run: |
-        echo "::add-path::$env:USERPROFILE\.poetry\bin"
+        echo "$env:USERPROFILE\.poetry\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: "Print Debug info"
       run: |


### PR DESCRIPTION
This command was deprecated due to a security issue. See
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
for more information.